### PR TITLE
Update epoch_user.tex, mu0 is permeability, epsilon0 is permittivity

### DIFF
--- a/epoch_user.tex
+++ b/epoch_user.tex
@@ -3918,8 +3918,8 @@ The maths parser in {\EPOCH}  has the following constants
 \item me - Mass of an electron.
 \item qe - Charge of an electron.
 \item c - Speed of light.
-\item epsilon0 - Permeability of free space.
-\item mu0 - Permittivity of free space.
+\item epsilon0 - Permittivity of free space.
+\item mu0 - Permeability of free space.
 \item ev - Electronvolt.
 \item kev - Kilo-Electronvolt.
 \item mev - Mega-Electronvolt.


### PR DESCRIPTION
In GitLab by James Cook (@jwscook) on 22 Oct 2020, 16:01  (GitLab merge request GL#58)

I just saw that `permeability` and `permittivity` were swapped in the user docs. Here's the fix.