### PR TITLE
Added preprocesor flag for WT interpolation

### DIFF
--- a/epoch_refs.bib
+++ b/epoch_refs.bib
@@ -194,3 +194,13 @@ doi = {10.1006/jcph.1998.6049}
   year={2018},
   publisher={Cambridge University Press}
 }
+
+@article{Lu2020,
+  author = {Lu, Y and Kilian, P and Guo, F and Li, H and Liang, E},
+  year = {2020},
+  volume = {413},
+  pages = {109388},
+  title = {Time-step dependent force interpolation scheme for suppressing numerical Cherenkov instability in relativistic particle-in-cell simulations},
+  journal = {Journal of Computational Physics},
+  doi = {10.1016/j.jcp.2020.109388},
+}

--- a/epoch_user.tex
+++ b/epoch_user.tex
@@ -414,6 +414,8 @@ symbol. The options currently controlled by the preprocessor are:\\
   function (0th order b-spline yielding a second order weighting).
 \item PARTICLE\_SHAPE\_BSPLINE3 - This flag changes the particle representation
   to that of a 3rd order b-spline shape function (5th order weighting).
+\item WT\_INTERPOLATION - When this option is enabled, the time-step dependent
+  force interpolation scheme (WT scheme from \citet{Lu2020}) is used.
 \item PARTICLE\_ID - When this option is enabled, all particles are assigned
   a unique identification number when writing particle data to file. This
   number can then be used to track the progress of a particle during the


### PR DESCRIPTION
In user guide added explanation for preprocessor flag `WT_INTERPOLATION`. This is for code implemented in (https://github.com/Warwick-Plasma/epoch/pull/313).